### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
         <testng.version>6.1.1</testng.version>
         <jacoco.core.version>0.7.5.201505241946</jacoco.core.version>
         <org.codehaus.plexus.version>3.0.22</org.codehaus.plexus.version>
-        <commons.collections.version>3.2.1</commons.collections.version>
+        <commons.collections.version>3.2.2</commons.collections.version>
         <lingala.zip4j.version>1.2.3</lingala.zip4j.version>
         <operadriver.version>0.8.1</operadriver.version>
         <selenium.version>2.43.0</selenium.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
