### PR TITLE
Adding Apis required for IS integration test restructuring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.wso2.carbon.automation</groupId>
     <artifactId>test-automation-framework</artifactId>
-    <version>4.4.3-SNAPSHOT</version>
+    <version>4.5.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>WSO2 Carbon Automation - Parent core project</name>

--- a/test-automation-framework/org.wso2.carbon.automation.artifacts/org.wso2.carbon.automation.coverage.report/pom.xml
+++ b/test-automation-framework/org.wso2.carbon.automation.artifacts/org.wso2.carbon.automation.coverage.report/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.automation</groupId>
         <artifactId>org.wso2.carbon.automation.artifacts</artifactId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/test-automation-framework/org.wso2.carbon.automation.artifacts/org.wso2.carbon.automation.remotecoverage/pom.xml
+++ b/test-automation-framework/org.wso2.carbon.automation.artifacts/org.wso2.carbon.automation.remotecoverage/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.wso2.carbon.automation</groupId>
         <artifactId>org.wso2.carbon.automation.artifacts</artifactId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>test-automation-artifact-remote-coverage</artifactId>
-    <version>4.4.3-SNAPSHOT</version>
+    <version>4.5.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>WSO2 Carbon Automation - Remote Coverage Jar</name>

--- a/test-automation-framework/org.wso2.carbon.automation.artifacts/pom.xml
+++ b/test-automation-framework/org.wso2.carbon.automation.artifacts/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.automation</groupId>
         <artifactId>test-automation-framework</artifactId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/test-automation-framework/org.wso2.carbon.automation.engine/pom.xml
+++ b/test-automation-framework/org.wso2.carbon.automation.engine/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.automation</groupId>
         <artifactId>test-automation-framework</artifactId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/test-automation-framework/org.wso2.carbon.automation.engine/src/main/java/org/wso2/carbon/automation/engine/context/TestUserMode.java
+++ b/test-automation-framework/org.wso2.carbon.automation.engine/src/main/java/org/wso2/carbon/automation/engine/context/TestUserMode.java
@@ -17,9 +17,21 @@
 */
 package org.wso2.carbon.automation.engine.context;
 
+/**
+ * Test User Mode Enum.
+ */
 public enum TestUserMode {
-    SUPER_TENANT_ADMIN,
-    SUPER_TENANT_USER,
-    TENANT_ADMIN,
-    TENANT_USER
+    SUPER_TENANT_ADMIN("super.tenant.admin"),
+    SUPER_TENANT_USER("super.tenant.user"),
+    TENANT_ADMIN("tenant.admin"),
+    TENANT_USER("tenant.user");
+
+    private String value;
+    TestUserMode(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
 }

--- a/test-automation-framework/org.wso2.carbon.automation.engine/src/main/java/org/wso2/carbon/automation/engine/frameworkutils/TestFrameworkUtils.java
+++ b/test-automation-framework/org.wso2.carbon.automation.engine/src/main/java/org/wso2/carbon/automation/engine/frameworkutils/TestFrameworkUtils.java
@@ -21,11 +21,14 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.automation.engine.extensions.ExtensionConstants;
 
 import javax.xml.xpath.XPathExpressionException;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This class contain util methods which can be used inside test framework and test cases
@@ -78,5 +81,18 @@ public class TestFrameworkUtils {
             throw new FileNotFoundException("Server startup script not found at " + carbonHome + File.separator + "bin");
         }
         return FilenameUtils.removeExtension(scriptName);
+    }
+
+    /**
+     * Returns a mapping of String to TestUserMode Enums.
+     *
+     * @return Map<String, TestUserMode> testUserModeMap
+     */
+    public static Map<String, TestUserMode> getTestUserModeMap(){
+        Map<String, TestUserMode> testUserModeMap = new HashMap<>();
+        for (TestUserMode testUserMode : TestUserMode.values()) {
+            testUserModeMap.put(testUserMode.getValue(), testUserMode);
+        }
+        return testUserModeMap;
     }
 }

--- a/test-automation-framework/org.wso2.carbon.automation.extensions/pom.xml
+++ b/test-automation-framework/org.wso2.carbon.automation.extensions/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.automation</groupId>
         <artifactId>test-automation-framework</artifactId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/ExtensionConstants.java
+++ b/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/ExtensionConstants.java
@@ -17,6 +17,9 @@
 */
 package org.wso2.carbon.automation.extensions;
 
+/**
+ * Constants that are required for Extensions and Listeners.
+ */
 public class ExtensionConstants {
     public static final String SYSTEM_PROPERTY_SETTINGS_LOCATION = "automation.settings.location";
     public static final String SYSTEM_ARTIFACT_RESOURCE_LOCATION = "framework.resource.location";
@@ -28,6 +31,7 @@ public class ExtensionConstants {
     public static final String SERVICE_FILE_SEC_VERIFIER = "SecVerifier.aar";
     public static final String SEVER_STARTUP_SCRIPT_NAME = "wso2server";
     public static final String SERVER_STARTUP_PORT_OFFSET_COMMAND = "-DportOffset";
+    public static final String SERVER_STARTUP_SETUP_COMMAND = "-Dsetup";
     public static final String COVERAGE_SERVER_STARTUP_PORT = "coverageServerPort";
     public static final String DEFAULT_COVERAGE_SERVER_STARTUP_PORT = "6300";
     public static final String COVERAGE_DUMP_FILE_PATH = "coverageDumpFilePath";

--- a/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/FrameworkExtensionUtils.java
+++ b/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/FrameworkExtensionUtils.java
@@ -18,8 +18,10 @@
 
 package org.wso2.carbon.automation.extensions;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.automation.engine.exceptions.AutomationFrameworkException;
 import org.wso2.carbon.automation.engine.frameworkutils.enums.OperatingSystems;
 
 import java.io.File;
@@ -28,29 +30,26 @@ public class FrameworkExtensionUtils {
 
     private static final Log log = LogFactory.getLog(FrameworkExtensionUtils.class);
 
-    public static String getSystemResourceLocation() {
-        String resourceLocation;
-        if (System.getProperty(ExtensionConstants.SYSTEM_PROPERTY_OS_NAME).
-                toLowerCase().contains(OperatingSystems.WINDOWS.name())) {
-            resourceLocation = System.getProperty(ExtensionConstants.SYSTEM_ARTIFACT_RESOURCE_LOCATION).replace("/", "\\");
-        } else {
-            resourceLocation = System.getProperty(ExtensionConstants.SYSTEM_ARTIFACT_RESOURCE_LOCATION).replace("/", "/");
-        }
-        return resourceLocation;
+    public static String getSystemResourceLocation() throws AutomationFrameworkException {
+        return getOSSensitivePath(System.getProperty(ExtensionConstants.SYSTEM_ARTIFACT_RESOURCE_LOCATION));
     }
 
+    /**
+     * Gives the absolute resource location.
+     *
+     * @param relativePath Relative path from system resource location. Relative path should not start with /.
+     * @return OS sensitive absolute resource location.
+     * @throws AutomationFrameworkException possible from getSystemResourceLocation() and getOSSensitivePath().
+     */
+    public static String getResourceLocation(String relativePath) throws
+            AutomationFrameworkException {
+        return getSystemResourceLocation() + getOSSensitivePath(relativePath);
+    }
 
-    public static String getSystemSettingsLocation() {
+    public static String getSystemSettingsLocation() throws AutomationFrameworkException {
         String settingsLocation;
         if (System.getProperty(ExtensionConstants.SYSTEM_PROPERTY_SETTINGS_LOCATION) != null) {
-            if (System.getProperty(ExtensionConstants.SYSTEM_PROPERTY_OS_NAME).toLowerCase().
-                    contains(OperatingSystems.WINDOWS.name())) {
-                settingsLocation =
-                        System.getProperty(ExtensionConstants.SYSTEM_PROPERTY_SETTINGS_LOCATION).replace("/", "\\");
-            } else {
-                settingsLocation =
-                        System.getProperty(ExtensionConstants.SYSTEM_PROPERTY_SETTINGS_LOCATION).replace("/", "/");
-            }
+            return getOSSensitivePath(System.getProperty(ExtensionConstants.SYSTEM_ARTIFACT_RESOURCE_LOCATION));
         } else {
             settingsLocation = getSystemResourceLocation();
         }
@@ -96,5 +95,28 @@ public class FrameworkExtensionUtils {
             carbonHome = null;
         }
         return carbonHome;
+    }
+
+    /**
+     * Gives the OS sensitive path.
+     *
+     * @param path File Path in linux standard. Should not be null.
+     * @return OS sensitive file path.
+     * @throws AutomationFrameworkException Throws when path is null.
+     */
+    public static String getOSSensitivePath(String path) throws AutomationFrameworkException {
+
+        String oSName = System.getProperty(ExtensionConstants.SYSTEM_PROPERTY_OS_NAME);
+        if (path == null) {
+            throw new AutomationFrameworkException("Path cannot be null");
+        } else if (StringUtils.isEmpty(oSName)) {
+            throw new AutomationFrameworkException("System property: " + ExtensionConstants.SYSTEM_PROPERTY_OS_NAME
+                    + " is empty.");
+        }
+
+        if (oSName.toLowerCase().contains(OperatingSystems.WINDOWS.name())) {
+            return path.replace("/", "\\");
+        }
+        return path;
     }
 }

--- a/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/servers/carbonserver/MultipleServersManager.java
+++ b/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/servers/carbonserver/MultipleServersManager.java
@@ -20,8 +20,6 @@ package org.wso2.carbon.automation.extensions.servers.carbonserver;
 
 import org.wso2.carbon.automation.engine.exceptions.AutomationFrameworkException;
 
-import javax.xml.xpath.XPathExpressionException;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -51,11 +49,7 @@ public class MultipleServersManager {
             String carbonHome = null;
             try {
                 carbonHome = zip.startServer();
-            } catch (IOException e) {
-                throw new AutomationFrameworkException("Server start failed", e);
             } catch (AutomationFrameworkException e) {
-                throw new AutomationFrameworkException("Server start failed", e);
-            } catch (XPathExpressionException e) {
                 throw new AutomationFrameworkException("Server start failed", e);
             }
             servers.put(carbonHome, zip);

--- a/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/servers/carbonserver/TestServerManager.java
+++ b/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/servers/carbonserver/TestServerManager.java
@@ -17,18 +17,24 @@
 */
 package org.wso2.carbon.automation.extensions.servers.carbonserver;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.automation.engine.FrameworkConstants;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
 import org.wso2.carbon.automation.engine.exceptions.AutomationFrameworkException;
 import org.wso2.carbon.automation.extensions.ExtensionConstants;
+import org.wso2.carbon.automation.extensions.FrameworkExtensionUtils;
 
-import javax.xml.xpath.XPathExpressionException;
+import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * This class is used mange a carbon server for integration tests.
+ */
 public class TestServerManager {
     protected CarbonServerManager carbonServer;
     protected String carbonZip;
@@ -80,6 +86,30 @@ public class TestServerManager {
 
     }
 
+    /**
+     * Apply the configuration changes from the given confChangesLocation.
+     * If the confChangesLocation is empty will not do anything.
+     *
+     * @param confChangesLocation location where the desired config changes are.
+     * @throws AutomationFrameworkException throw if carbonHome is not defined or copy config fails.
+     */
+    public void configureServer(String confChangesLocation) throws AutomationFrameworkException {
+        if (StringUtils.isNotEmpty(confChangesLocation)) {
+            if (StringUtils.isEmpty(carbonHome)) {
+                throw new AutomationFrameworkException("Carbon Home is not set. Therefore cannot copy configuration " +
+                        "changes from " + confChangesLocation);
+            }
+            File sourceDir = new File(FrameworkExtensionUtils.getOSSensitivePath(confChangesLocation));
+            File destinationDir = new File(carbonHome + File.separator + "repository" + File.separator + "conf");
+            try {
+                FileUtils.copyDirectory(sourceDir, destinationDir);
+            } catch (IOException e) {
+                throw new AutomationFrameworkException("Error while copying config files form" + sourceDir.getPath()
+                        + " to " + destinationDir.getPath());
+            }
+        }
+    }
+
 
     public Map<String, String> getCommands() {
         return commandMap;
@@ -95,23 +125,41 @@ public class TestServerManager {
      * @throws java.io.IOException If an error occurs while copying the deployment artifacts into the
      *                             Carbon server
      */
-    public String startServer()
-            throws AutomationFrameworkException, IOException, XPathExpressionException {
-        if(carbonHome == null) {
+    public String startServer() throws AutomationFrameworkException {
+        return startServer(StringUtils.EMPTY);
+    }
+
+    /**
+     * This method starts a carbon server in preparation for execution of a test suite.
+     * Before starting the server copies the configuration files from the given conf location
+     * to the carbon server conf directory.
+     *
+     * @param confChangesLocation  Directory location of the desired configuration files.
+     * @return The carbon home.
+     * @throws AutomationFrameworkException Possible when carbonZip cannot be found and when setting up carbon home.
+     */
+    public String startServer(String confChangesLocation) throws AutomationFrameworkException {
+        if (carbonHome == null) {
             if (carbonZip == null) {
                 carbonZip = System.getProperty(FrameworkConstants.SYSTEM_PROPERTY_CARBON_ZIP_LOCATION);
             }
             if (carbonZip == null) {
-                throw new IllegalArgumentException("carbon zip file cannot find in the given location");
+                throw new AutomationFrameworkException("Carbon zip file cannot be found in the given " +
+                        FrameworkConstants.SYSTEM_PROPERTY_CARBON_ZIP_LOCATION + " location.");
             }
-            carbonHome = carbonServer.setUpCarbonHome(carbonZip);
-            configureServer();
+
+            try {
+                carbonHome = carbonServer.setUpCarbonHome(carbonZip);
+            } catch (IOException e) {
+                throw new AutomationFrameworkException("Error while setting up carbon home.", e);
+            }
+            configureServer(confChangesLocation);
         }
         log.info("Carbon Home - " + carbonHome);
         if (commandMap.get(ExtensionConstants.SERVER_STARTUP_PORT_OFFSET_COMMAND) != null) {
             this.portOffset = Integer.parseInt(commandMap.get(ExtensionConstants.SERVER_STARTUP_PORT_OFFSET_COMMAND));
         } else {
-            this.portOffset = 0;
+            this.portOffset = ExtensionConstants.DEFAULT_CARBON_PORT_OFFSET;
         }
         carbonServer.startServerUsingCarbonHome(carbonHome, commandMap);
         return carbonHome;
@@ -139,8 +187,4 @@ public class TestServerManager {
     public void stopServer() throws AutomationFrameworkException {
         carbonServer.serverShutdown(portOffset);
     }
-
-
-
-
 }

--- a/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/servers/carbonserver/TestServerManager.java
+++ b/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/servers/carbonserver/TestServerManager.java
@@ -100,7 +100,7 @@ public class TestServerManager {
                         "changes from " + confChangesLocation);
             }
             File sourceDir = new File(FrameworkExtensionUtils.getOSSensitivePath(confChangesLocation));
-            File destinationDir = new File(carbonHome + File.separator + "repository" + File.separator + "conf");
+            File destinationDir = new File(carbonHome + File.separator + "repository");
             try {
                 FileUtils.copyDirectory(sourceDir, destinationDir);
             } catch (IOException e) {

--- a/test-automation-framework/org.wso2.carbon.automation.test.utils/pom.xml
+++ b/test-automation-framework/org.wso2.carbon.automation.test.utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.automation</groupId>
         <artifactId>test-automation-framework</artifactId>
-        <version>4.4.3-SNAPSHOT</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Purpose
> In the effort of IS Integration test restructuring came across the requirement of some additional APIs. The following are the introduced APIs.
TestServerManager
1 ConfigureServer(String confChangesLocation)
2 startServer(String confChangesLocation)
FrameworkExtensionUtils
3 appendToSystemResourceLocation(String pathToAppend)

## Goals
> Get required APIs exposed for IS Integration test restructuring effort.

## Release note
> Since public APIs are introduced but not the Existing APIs are changed or removed bumping up the minor version would be enough.Bumping up of the minor version is done in this PR.