### PR TITLE
Make code coverage classes directory configurable

### DIFF
--- a/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/servers/carbonserver/CarbonServerManager.java
+++ b/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/servers/carbonserver/CarbonServerManager.java
@@ -17,6 +17,7 @@ package org.wso2.carbon.automation.extensions.servers.carbonserver;
 
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.automation.engine.FrameworkConstants;
@@ -50,6 +51,7 @@ public class CarbonServerManager {
     private ServerLogReader inputStreamHandler;
     private ServerLogReader errorStreamHandler;
     private boolean isCoverageEnable = false;
+    private String coverageClassesDir;
     private String coverageDumpFilePath;
     private int portOffset = 0;
     private static final String SERVER_SHUTDOWN_MESSAGE = "Halting JVM";
@@ -202,6 +204,8 @@ public class CarbonServerManager {
         try {
             //read coverage status from automation.xml
             isCoverageEnable = Boolean.parseBoolean(automationContext.getConfigurationValue("//coverage"));
+            // read optional coverage classes relative directory from automation.xml
+            coverageClassesDir = automationContext.getConfigurationValue("//coverageClassesRelativeDirectory");
         } catch (XPathExpressionException e) {
             throw new AutomationFrameworkException("Coverage configuration not found in automation.xml", e);
         }
@@ -257,9 +261,11 @@ public class CarbonServerManager {
             if (isCoverageEnable) {
                 try {
                     log.info("Generating Jacoco code coverage...");
+                    coverageClassesDir = StringUtils.isEmpty(coverageClassesDir) ? "repository" +
+                            File.separator + "components" + File.separator + "plugins" + File.separator :
+                            coverageClassesDir;
                     generateCoverageReport(
-                            new File(carbonHome + File.separator + "repository" +
-                                     File.separator + "components" + File.separator + "plugins" + File.separator));
+                            new File(carbonHome + File.separator + coverageClassesDir));
                 } catch (IOException e) {
                     log.error("Failed to generate code coverage ", e);
                     throw new AutomationFrameworkException("Failed to generate code coverage ", e);


### PR DESCRIPTION
## Purpose
- WSO2 carbon products usually have the source code in plugins directory
- When it comes to vertical solutions like healthcare, BFSI - the source
code specific to the solutions goes under dropins folder of the base products.
- So, in the vertical solutions, when we run the integration tests, we need
the ability to point to dropins directory in order to generate the code
coverage reports of the solution.

## Approach
- Solution is to make this classes directory configurable via the automation.xml
- `coverageClassesRelativeDirectory` is an optional element under
automation/configurations element of the automation.xml

<!-- Set this to the relative path of the directory, where the classes you
need to instrument through code coverage tool, resides. By default this is
pointed to the plugins directory of a WSO2 Carbon Server -->
<coverageClassesRelativeDirectory>repository/components/dropins/
                                       </coverageClassesRelativeDirectory>

- Value of coverageClassesRelativeDirectory is a relative path from the
carbon_home.
- By default, when you don't set this in automation.xml, framework will
use the plugins directory as the classes directory for Jacoco report
generation.
