### PR TITLE
Update dependencies to work with Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,14 +48,39 @@
 
     <repositories>
         <repository>
-            <id>saucelabs-repository</id>
-            <url>https://repository-saucelabs.forge.cloudbees.com/release</url>
+            <id>wso2.releases</id>
+            <name>WSO2 Releases Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
             <releases>
                 <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
             </releases>
+        </repository>
+
+        <!-- WSO2 Snapshot artifact repository -->
+        <repository>
+            <id>wso2.snapshots</id>
+            <name>WSO2 Snapshot Repository</name>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
             </snapshots>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
+
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
         </repository>
     </repositories>
 
@@ -386,8 +411,8 @@
         <axis2.wso2.version>1.6.1-wso2v37</axis2.wso2.version>
 
         <!-- Other dependencies -->
-        <testng.version>6.1.1</testng.version>
-        <jacoco.core.version>0.7.5.201505241946</jacoco.core.version>
+        <testng.version>7.10.1</testng.version>
+        <jacoco.core.version>0.8.12</jacoco.core.version>
         <org.codehaus.plexus.version>3.0.22</org.codehaus.plexus.version>
         <commons.collections.version>3.2.1</commons.collections.version>
         <lingala.zip4j.version>1.2.3</lingala.zip4j.version>

--- a/test-automation-framework/org.wso2.carbon.automation.engine/pom.xml
+++ b/test-automation-framework/org.wso2.carbon.automation.engine/pom.xml
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.1.201405082137</version>
+                <version>${jacoco.core.version}</version>
                 <executions>
                     <execution>
                         <id>default-prepare-agent</id>
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.17</version>
+                <version>3.2.5</version>
                 <executions>
                     <execution>
                         <id>default-test</id>
@@ -72,7 +72,7 @@
                     <forkCount>1</forkCount>
                     <reuseForks>true</reuseForks>
                     <argLine>
-                        -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/0.7.1.201405082137/org.jacoco.agent-0.7.1.201405082137-runtime.jar=destfile=${project.build.directory}/jacoco.exec
+                        -javaagent:${settings.localRepository}/org/jacoco/org.jacoco.agent/${jacoco.core.version}/org.jacoco.agent-${jacoco.core.version}-runtime.jar=destfile=${project.build.directory}/jacoco.exec
                     </argLine>
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>

--- a/test-automation-framework/org.wso2.carbon.automation.engine/src/main/java/org/wso2/carbon/automation/engine/frameworkutils/CodeCoverageUtils.java
+++ b/test-automation-framework/org.wso2.carbon.automation.engine/src/main/java/org/wso2/carbon/automation/engine/frameworkutils/CodeCoverageUtils.java
@@ -520,8 +520,26 @@ public final class CodeCoverageUtils {
 
         while (waitTime > System.currentTimeMillis()) {
             if (file.length() > 0) {
+                long length1 = file.length();
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    log.warn("Sleep interrupted ", e);
+                }
+                long length2 = file.length();
+                if (length1 != length2) {
+                    log.info("Execution data file non empty file " + file.getAbsolutePath() +
+                            " is still being written.");
+                    try {
+                        Thread.sleep(400);
+                    } catch (InterruptedException e) {
+                        log.warn("Sleep interrupted ", e);
+                    }
+                    continue;
+                }
                 status = true;
-                log.info("Execution data file non empty file size in KB : " + file.length() / 1024);
+                log.info("Execution data file non empty file " + file.getAbsolutePath() + " size in KB : " +
+                        file.length() / 1024);
                 break;
             } else {
 

--- a/test-automation-framework/org.wso2.carbon.automation.engine/src/main/java/org/wso2/carbon/automation/engine/testlisteners/TestTransformerListener.java
+++ b/test-automation-framework/org.wso2.carbon.automation.engine/src/main/java/org/wso2/carbon/automation/engine/testlisteners/TestTransformerListener.java
@@ -21,7 +21,6 @@ package org.wso2.carbon.automation.engine.testlisteners;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.testng.IAnnotationTransformer;
-import org.testng.IAnnotationTransformer2;
 import org.testng.annotations.IConfigurationAnnotation;
 import org.testng.annotations.IDataProviderAnnotation;
 import org.testng.annotations.IFactoryAnnotation;
@@ -39,7 +38,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 
-public class TestTransformerListener implements IAnnotationTransformer, IAnnotationTransformer2 {
+public class TestTransformerListener implements IAnnotationTransformer {
 
     private static final Log log = LogFactory.getLog(TestTransformerListener.class);
     private AutomationContext context;

--- a/test-automation-framework/org.wso2.carbon.automation.engine/src/test/java/org/wso2/carbon/automation/engine/test/context/AutomationContextTestCase.java
+++ b/test-automation-framework/org.wso2.carbon.automation.engine/src/test/java/org/wso2/carbon/automation/engine/test/context/AutomationContextTestCase.java
@@ -18,11 +18,11 @@
 
 package org.wso2.carbon.automation.engine.test.context;
 
-import junit.framework.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Factory;
 import org.testng.annotations.Test;
+import org.testng.Assert;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 
@@ -54,7 +54,8 @@ public class AutomationContextTestCase {
 
     @Test(groups = "context.unit.test", description = "Upload aar service and verify deployment")
     public void testGetSuperTenant() throws XPathExpressionException {
-        Assert.assertTrue(context.getSuperTenant().getTenantAdmin().getUserName().equals("admin"));
+
+        Assert.assertEquals(context.getSuperTenant().getTenantAdmin().getUserName(), "admin");
     }
 
     @Test(groups = "context.unit.test", description = "Upload aar service and verify deployment")
@@ -73,11 +74,15 @@ public class AutomationContextTestCase {
     }
     @Test(groups = "context.unit.test", description = "Upload aar service and verify deployment")
     public void testGetConfigNode() throws XPathExpressionException {
-        Assert.assertTrue(context.getConfigurationNode("//datasources/datasource[@name='dataService']").getChildNodes().item(2).getNodeName().equals("password"));
+
+        Assert.assertEquals(
+                context.getConfigurationNode("//datasources/datasource[@name='dataService']").getChildNodes().item(2)
+                        .getNodeName(), "password");
     }
     @Test(groups = "context.unit.test", description = "Upload aar service and verify deployment")
     public void testGetCofigNodeList() throws XPathExpressionException {
-        Assert.assertTrue(context.getConfigurationNodeList("//datasources/datasource").getLength()==2);
+
+        Assert.assertEquals(context.getConfigurationNodeList("//datasources/datasource").getLength(), 2);
     }
     @Test(groups = "context.unit.test", description = "Upload aar service and verify deployment")
     public void testGetDefaultInstance() throws XPathExpressionException {

--- a/test-automation-framework/org.wso2.carbon.automation.extensions/pom.xml
+++ b/test-automation-framework/org.wso2.carbon.automation.extensions/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.17</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>default-test</id>
@@ -47,7 +47,12 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <argLine>-Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m</argLine>
+                    <argLine>
+                        -Xmx1024m
+                        --add-opens=java.base/java.util=ALL-UNNAMED
+                        --add-opens=java.base/java.text=ALL-UNNAMED
+                        --add-opens=java.desktop/java.awt.font=ALL-UNNAMED
+                    </argLine>
                     <forkCount>1</forkCount>
                     <reuseForks>true</reuseForks>
                     <suiteXmlFiles>

--- a/test-automation-framework/org.wso2.carbon.automation.test.utils/pom.xml
+++ b/test-automation-framework/org.wso2.carbon.automation.test.utils/pom.xml
@@ -36,7 +36,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.17</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>default-test</id>
@@ -60,6 +60,10 @@
 
 
     <dependencies>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>


### PR DESCRIPTION
## Purpose
Update dependencies to work with Java 17

TestNG has removed org.testng.IAnnotationTransformer2 from latest version and hence using this component with latest testNG version does not work. So to update the TestNG version such dependent component, TestNG version needs to be updated here.