### PR TITLE
Add email sender configs

### DIFF
--- a/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/XPathConstants.java
+++ b/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/XPathConstants.java
@@ -52,5 +52,5 @@ public class XPathConstants {
     public static final String COVERAGE_CLASSES_RELATIVE_DIRECTORY = "//coverageClassesRelativeDirectory";
     public static final String COVERAGE_CLASSES_RELATIVE_DIRECTORIES = "//coverageClassesRelativeDirectories";
     public static final String COVERAGE_CLASSES_RELATIVE_DIRECTORY_NODE_NAME = "coverageClassesRelativeDirectory";
-
+    public static final String EMAIL_SENDER_CONFIGS = "//emailSenderConfigs";
 }


### PR DESCRIPTION
## Purpose
Provide a way to configure a email sender during the suite initialization.

Part of https://github.com/wso2/product-is/issues/21187

## Approach
Adding below tag within the `<automation>` tag populates the `[output_adapter.email]` in the deployment.toml

    <emailSenderConfigs>
        <from_address>admin@wso2.com</from_address>
        <username>admin</username>
        <password>admin</password>
        <hostname>localhost</hostname>
        <port>3025</port>
        <enable_start_tls>true</enable_start_tls>
        <enable_authentication>true</enable_authentication>
    </emailSenderConfigs>

