### PR TITLE
Reduce wait time after port open in carbon server startup

### DIFF
--- a/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/servers/carbonserver/CarbonServerManager.java
+++ b/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/servers/carbonserver/CarbonServerManager.java
@@ -128,7 +128,7 @@ public class CarbonServerManager {
                                              automationContext.getInstance().getHosts().get("default"));
 
             //wait until Mgt console url printed.
-            long time = System.currentTimeMillis() + 60 * 1000;
+            long time = System.currentTimeMillis() + 2 * 1000;
             while (!inputStreamHandler.getOutput().contains(SERVER_STARTUP_MESSAGE) &&
                    System.currentTimeMillis() < time) {
                 // wait until server startup is completed


### PR DESCRIPTION
## Purpose
$subject.

As of now it waits full 1 minute after the the having the ports of the servlet transport open.

```
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - [2024-12-03 21:58:48,098] []  INFO {org.wso2.carbon.core.internal.StartupFinalizerServiceComponent} - WSO2 Carbon started in 36 sec
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - [2024-12-03 21:58:48,109] []  INFO {org.wso2.carbon.healthcheck.api.core.internal.HealthMonitorServiceComponent} - Carbon health monitoring service is activated..
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - [2024-12-03 21:58:48,319] []  INFO {org.apache.jasper.servlet.TldScanner} - At least one JAR was scanned for TLDs yet contained no TLDs. Enable debug logging for this logger for a complete list of JARs that were scanned but no TLDs were found in them. Skipping unneeded JARs during scanning can improve startup time and JSP compilation time.

[waits for 1 minute]

INFO  [org.wso2.carbon.automation.extensions.servers.utils.ClientConnectionUtil] - Waiting for user login...
WARN  [org.apache.axiom.util.stax.dialect.StAXDialectDetector] - Unable to determine dialect of the StAX implementation at jar:file:/Users/darshana/.m2/repository/org/apache/ws/commons/axiom/wso2/axiom/1.2.11-wso2v16/axiom-1.2.11-wso2v16.jar!/
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ClientConnectionUtil] - https://localhost:9853/services
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - [2024-12-03 21:59:48,970] [d3509133-21b4-4da5-b8cb-fd9bcf08ef62]  INFO {org.wso2.carbon.core.services.util.CarbonAuthenticationUtil} - 'admin@carbon.super [-1234]' logged in at [2024-12-03 21:59:48,970+0530]
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ClientConnectionUtil] - Login was successful..
```

This wait is too much, hence reducing the wait time to `60s` to `2s`.

## Goals
Reduce the test execution time, specially when running few tests classes, it takes around 3minutes.. With this improvement, it reduced to 2minutes..
