### PR TITLE
Enable admin services in the integration tests.

### DIFF
--- a/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/XPathConstants.java
+++ b/test-automation-framework/org.wso2.carbon.automation.extensions/src/main/java/org/wso2/carbon/automation/extensions/XPathConstants.java
@@ -54,4 +54,8 @@ public class XPathConstants {
     public static final String COVERAGE_CLASSES_RELATIVE_DIRECTORY_NODE_NAME = "coverageClassesRelativeDirectory";
     public static final String EMAIL_SENDER_CONFIGS = "//emailSenderConfigs";
     public static final String LOGGING_CONFIGS = "//loggingConfigs";
+    public static final String ENABLE_ADMIN_SERVICES = "//enableAdminServices";
+    public static final String ENABLE_ADMIN_SERVICES_PARENT_KEY = "expectedParentKey";
+    public static final String ENABLE_ADMIN_SERVICES_KEY = "expectedKey";
+    public static final String ENABLE_ADMIN_SERVICES_VALUE = "expectedValue";
 }


### PR DESCRIPTION
## Purpose

Part of https://github.com/wso2/product-is/issues/20755

With improvement https://github.com/wso2/carbon-kernel/pull/4361, admin services are disabled by default in the IS server. However, to run the integration tests, admin services need to be enabled again.



## Approach
Adding below tag within the `<automation>` tag populates the `[server.disable_admin_services]` in the deployment.toml

  ```
   <enableAdminServices>
        <expectedParentKey>server</expectedParentKey>
        <expectedKey>disable_admin_services</expectedKey>
        <expectedValue>false</expectedValue>
   </enableAdminServices>
  ```
